### PR TITLE
Added branch option to smartClone action

### DIFF
--- a/ActionsRegistry.js
+++ b/ActionsRegistry.js
@@ -352,6 +352,9 @@ function ActionsRegistry() {
             } else {
                 global.collectLog = true;
             }
+            if(typeof action.branch === "string") {
+                options.branch = action.branch;
+            }
 
             if (typeof action.commit !== "undefined") {
                 //Do a shallow clone (for a specific commit)


### PR DESCRIPTION
This will allow to pass a certain branch to **smartClone** step (overwriting the default **master** branch)